### PR TITLE
Telegram bot API shell script

### DIFF
--- a/telegram_bot_send_message.sh
+++ b/telegram_bot_send_message.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -o nounset
+
+REQUIRED_VARS=(
+	CHAT_ID
+	BOT_ID
+	API_KEY
+)
+
+for v in ${REQUIRED_VARS[@]}; do
+	set $v=${!v-$(1>&2 echo "ERROR: $v is unset, please set this environment variable" ; exit 1)}
+done
+
+curl -s -X GET "https://api.telegram.org/$BOT_ID:$API_KEY/sendMessage" -d parse_mode=html -d chat_id=CHAT_ID -d text="$*" > /dev/null

--- a/telegram_bot_send_message.sh
+++ b/telegram_bot_send_message.sh
@@ -11,4 +11,4 @@ for v in ${REQUIRED_VARS[@]}; do
 	set $v=${!v-$(1>&2 echo "ERROR: $v is unset, please set this environment variable" ; exit 1)}
 done
 
-curl -s -X GET "https://api.telegram.org/$BOT_ID:$API_KEY/sendMessage" -d parse_mode=html -d chat_id=CHAT_ID -d text="$*" > /dev/null
+curl -s -X GET "https://api.telegram.org/$BOT_ID:$API_KEY/sendMessage" -d parse_mode=html -d chat_id=$CHAT_ID -d text="$*" > /dev/null


### PR DESCRIPTION
A `curl` wrapper for testing the telegram bot. It needs `API_KEY`, `BOT_ID` and `CHAT_ID` exported to its environment for the bot to be authenticated, which bot, and who to send the message to.